### PR TITLE
fix: Update to OpenJDK 21 for Debian Trixie compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
         ca-certificates \
         gnupg \
         openssl \
-        openjdk-17-jre-headless \
+        openjdk-21-jre-headless \
         iputils-ping \
         git \
         wget \


### PR DESCRIPTION
OpenJDK 17 is no longer available in Debian Trixie. The package openjdk-17-jre-headless has been replaced by openjdk-21-jre-headless.