### PR TITLE
fix: redis single replica configuration

### DIFF
--- a/setup/values-gdcn.yaml
+++ b/setup/values-gdcn.yaml
@@ -73,8 +73,13 @@ etcd:
   replicaCount: 1
 
 redis-ha:
-  replicaCount: 1
+  replicas: 1
   hardAntiAffinity: false
+  redis:
+    config:
+      min-replicas-to-write: 0
+  sentinel:
+    quorum: 1
 
 tools:
   replicaCount: 0


### PR DESCRIPTION
In the dev sizing profile, Redis isn't configured properly to be a single replica service. This adds that configuration.